### PR TITLE
Eliminate "Category is implementing a method which will also be implemented by its primary class" warning.

### DIFF
--- a/FayeObjc/Extensions/NSObject+PropertySupport.m
+++ b/FayeObjc/Extensions/NSObject+PropertySupport.m
@@ -10,12 +10,6 @@
 #import "NSObject+PropertySupport.h"
 #import "NSString+InflectionSupport.h"
 
-@interface NSObject()
-
-+ (NSString *) getPropertyType:(NSString *)attributeString;
-
-@end
-
 
 @implementation NSObject (PropertySupport)
 + (NSArray *)propertyNames {


### PR DESCRIPTION
I don't _think_ that you need to declare this method in both the named category and the class extension.
