### PR TITLE
Message IDs should be sequential and compact

### DIFF
--- a/FayeObjc/FayeClient.h
+++ b/FayeObjc/FayeClient.h
@@ -69,6 +69,7 @@ enum _fayeStates {
   BOOL fayeConnected;  
   NSDictionary *connectionExtension;
   BOOL connectionInitiated;
+  uint32_t messageNumber;
 }
 
 @property (strong) NSString *fayeURLString;

--- a/FayeObjc/FayeClient.m
+++ b/FayeObjc/FayeClient.m
@@ -192,6 +192,26 @@
   }
 }
 
+- (NSString *) base36Encode:(uint32_t)value
+{
+  NSString *base36 = @"0123456789abcdefghijklmnopqrstuvwxyz";
+  NSString *buffer = @"";
+  
+  do {
+    NSString *newChar = [NSString stringWithFormat:@"%c", [base36 characterAtIndex:(value % 36)]];
+    buffer = [newChar stringByAppendingString:buffer];
+  } while (value /= 36);
+  
+  return buffer;
+}
+
+- (NSString *) nextMessageId
+{
+  messageNumber++;
+  if (messageNumber >= UINT32_MAX) messageNumber = 0;
+  
+  return [self base36Encode:messageNumber];
+}
 
 #pragma mark -
 #pragma mark WebSocket connection
@@ -306,7 +326,7 @@
     return;
   }
   
-  NSString *messageId = [NSString stringWithFormat:@"msg_%d_%d", (int)[[NSDate date] timeIntervalSince1970], 1];
+  NSString *messageId = [self nextMessageId];
   NSDictionary *dict = nil;
   
   if(nil == extension) {


### PR DESCRIPTION
Here's a patch that generates message ids by incrementing a 32-bit unsigned integer, and base 36 encoding it on the way out to keep it compact.
