### PR TITLE
EXC_BAD_ACCESS (code=1) on disconnect from server

### DIFF
--- a/src/FayeClient.m
+++ b/src/FayeClient.m
@@ -193,6 +193,7 @@
 #pragma mark Deallocation
 - (void) dealloc
 {
+  self.webSocket.delegate = nil;
   self.delegate = nil;
 }
 

--- a/src/FayeClient.m
+++ b/src/FayeClient.m
@@ -193,7 +193,8 @@
 #pragma mark Deallocation
 - (void) dealloc
 {
-  self.webSocket.delegate = nil;
+  // clean up any existing socket
+  [self closeWebSocketConnection];
   self.delegate = nil;
 }
 
@@ -264,17 +265,19 @@
 #pragma mark -
 #pragma mark WebSocket connection
 - (void) openWebSocketConnection {
-  // clean up any existing socket    
-  [webSocket setDelegate:nil];
-  [webSocket close];
+  // clean up any existing socket
+  [self closeWebSocketConnection];
+  
   webSocket = [[SRWebSocket alloc] initWithURLRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:self.fayeURLString]]];
   webSocket.delegate = self;
   self.connectionInitiated = YES;
   [webSocket open];
 }
 
-- (void) closeWebSocketConnection { 
-  [webSocket close];	    
+- (void) closeWebSocketConnection {
+  [webSocket setDelegate:nil];
+  [webSocket close];
+  webSocket = nil;
 }
 
 #pragma mark -


### PR DESCRIPTION
Firstly, thanks for a great library, along with Faye, I've found it to be really useful!

For various reasons, my application tends to recycle it's Faye client from time-to-time (connecting to different URLS, reauthenticating, disconnecting the client when the connection is not required, etc). I frequently experience problems with dangling non-safe weak references shortly after disconnecting the Faye connecting, especially if I release my FayeClient before the server has responded to the disconnect message.

The problem occurs in objc_retain, when trying to perform `webSocket:didReceiveMessage` in `SRWebSocket's_handleMessage`

```
- (void)_handleMessage:(id)message
{
    SRFastLog(@"Received message");
    [self _performDelegateBlock:^{
        [self.delegate webSocket:self didReceiveMessage:message];
    }];
}
```

The reason it's happening is that the delegate is not being nulled out before the delegate object is disposed. This patch seems to fix the problem for me.
